### PR TITLE
Use visitor pattern for AST

### DIFF
--- a/src/main/cup/flowg.cup
+++ b/src/main/cup/flowg.cup
@@ -38,7 +38,7 @@ decl ::= TYPE:t IDENTIFIER:i ASSIGNMENT expr:e
         {: RESULT = new DeclarationNode(t, i, e); :};
 
 expr ::= NUMBER_LITERAL:n
-        {: RESULT = new ExpressionNode(n); :}
+        {: RESULT = n; :}
         | BOOLEAN_LITERAL:b
-        {: RESULT = new ExpressionNode(b); :}
+        {: RESULT = b; :}
         ;

--- a/src/main/java/org/flowsoft/flowg/IVisitor.java
+++ b/src/main/java/org/flowsoft/flowg/IVisitor.java
@@ -1,0 +1,14 @@
+package org.flowsoft.flowg;
+
+import org.flowsoft.flowg.nodes.*;
+
+public interface IVisitor<T> {
+    T Visit(ProgramNode programNode);
+    T Visit(StatementListNode statementListNode);
+    T Visit(StatementNode statementNode);
+    T Visit(DeclarationNode declarationNode);
+    T Visit(TypeNode typeNode);
+    T Visit(IdentifierNode identifierNode);
+    T Visit(NumberLiteralNode numberLiteralNode);
+    T Visit(BooleanLiteralNode booleanLiteralNode);
+}

--- a/src/main/java/org/flowsoft/flowg/PrettyPrintingVisitor.java
+++ b/src/main/java/org/flowsoft/flowg/PrettyPrintingVisitor.java
@@ -1,0 +1,52 @@
+package org.flowsoft.flowg;
+
+import org.flowsoft.flowg.nodes.*;
+
+public class PrettyPrintingVisitor implements IVisitor<String> {
+    @Override
+    public String Visit(ProgramNode programNode) {
+        return programNode.GetChild().Accept(this);
+    }
+
+    @Override
+    public String Visit(StatementListNode statementListNode) {
+        var statement = statementListNode.GetStatementChild();
+        var statementList = statementListNode.GetStatementListChild();
+
+        return statement.Accept(this) + ";\n"
+                + (statementList == null ? "" : statementList.Accept(this));
+    }
+
+    @Override
+    public String Visit(StatementNode statementNode) {
+        return statementNode.GetChild().Accept(this);
+    }
+
+    @Override
+    public String Visit(DeclarationNode declarationNode) {
+        return declarationNode.GetTypeChild().Accept(this)
+                + " " + declarationNode.GetIdentifierChild().Accept(this)
+                + " ="
+                + " " + declarationNode.GetExpressionChild().Accept(this);
+    }
+
+    @Override
+    public String Visit(TypeNode typeNode) {
+        return typeNode.GetValue();
+    }
+
+    @Override
+    public String Visit(IdentifierNode identifierNode) {
+        return identifierNode.GetValue();
+    }
+
+    @Override
+    public String Visit(NumberLiteralNode numberLiteralNode) {
+        return numberLiteralNode.GetValue().toString();
+    }
+
+    @Override
+    public String Visit(BooleanLiteralNode booleanLiteralNode) {
+        return booleanLiteralNode.GetValue().toString();
+    }
+}

--- a/src/main/java/org/flowsoft/flowg/TreePrintingVisitor.java
+++ b/src/main/java/org/flowsoft/flowg/TreePrintingVisitor.java
@@ -1,0 +1,69 @@
+package org.flowsoft.flowg;
+
+import org.flowsoft.flowg.nodes.*;
+
+public class TreePrintingVisitor implements IVisitor<String> {
+
+    private int _indentation = 0;
+
+    private String PrintNode(INode node) {
+
+        return "  ".repeat(_indentation) + node.toString() + "\n";
+    }
+
+    private String PrintNode(INode node, INode... children) {
+        var str = PrintNode(node);
+        _indentation++;
+        for (var child : children) {
+            str += child.Accept(this);
+        }
+        _indentation--;
+
+        return str;
+    }
+
+    @Override
+    public String Visit(ProgramNode programNode) {
+        return PrintNode(programNode, programNode.GetChild());
+    }
+
+    @Override
+    public String Visit(StatementListNode statementListNode) {
+        if (statementListNode.GetStatementListChild() == null){
+            return PrintNode(statementListNode, statementListNode.GetStatementChild());
+        }
+        else {
+            return PrintNode(statementListNode, statementListNode.GetStatementChild(), statementListNode.GetStatementListChild());
+        }
+    }
+
+    @Override
+    public String Visit(StatementNode statementNode) {
+        return PrintNode(statementNode, statementNode.GetChild());
+    }
+
+    @Override
+    public String Visit(DeclarationNode declarationNode) {
+        return PrintNode(declarationNode, declarationNode.GetTypeChild(), declarationNode.GetIdentifierChild(), declarationNode.GetExpressionChild());
+    }
+
+    @Override
+    public String Visit(TypeNode typeNode) {
+        return PrintNode(typeNode);
+    }
+
+    @Override
+    public String Visit(IdentifierNode identifierNode) {
+        return PrintNode(identifierNode);
+    }
+
+    @Override
+    public String Visit(NumberLiteralNode numberLiteralNode) {
+        return PrintNode(numberLiteralNode);
+    }
+
+    @Override
+    public String Visit(BooleanLiteralNode booleanLiteralNode) {
+        return PrintNode(booleanLiteralNode);
+    }
+}

--- a/src/main/java/org/flowsoft/flowg/main.java
+++ b/src/main/java/org/flowsoft/flowg/main.java
@@ -24,7 +24,9 @@ public class main {
         try {
             var symbol = parser.debug_parse();
             PrintSymbol(symbol);
-            ((Node)symbol.value).Print();
+            var rootNode = (Node)symbol.value;
+            System.out.println(rootNode.Accept(new TreePrintingVisitor()));
+            System.out.println(rootNode.Accept(new PrettyPrintingVisitor()));
         }
         catch (Exception e) {
             System.out.println("Could not parse");

--- a/src/main/java/org/flowsoft/flowg/nodes/BooleanLiteralNode.java
+++ b/src/main/java/org/flowsoft/flowg/nodes/BooleanLiteralNode.java
@@ -1,11 +1,20 @@
 package org.flowsoft.flowg.nodes;
 
-public class BooleanLiteralNode extends Node {
+import org.flowsoft.flowg.IVisitor;
+
+public class BooleanLiteralNode extends Node implements ExpressionNode {
+    private final Boolean _value;
+
     public BooleanLiteralNode(Boolean value) {
-        super(value);
+        _value = value;
     }
 
     public Boolean GetValue() {
-        return (Boolean) value;
+        return _value;
+    }
+
+    @Override
+    public <T> T Accept(IVisitor<T> visitor) {
+        return visitor.Visit(this);
     }
 }

--- a/src/main/java/org/flowsoft/flowg/nodes/DeclarationNode.java
+++ b/src/main/java/org/flowsoft/flowg/nodes/DeclarationNode.java
@@ -1,19 +1,32 @@
 package org.flowsoft.flowg.nodes;
 
+import org.flowsoft.flowg.IVisitor;
+
 public class DeclarationNode extends Node {
+    private final TypeNode _type;
+    private final IdentifierNode _identifier;
+    private final ExpressionNode _expression;
+
     public DeclarationNode(TypeNode type, IdentifierNode identifier, ExpressionNode expression) {
-        super(new Node[] {type, identifier, expression});
+        _type = type;
+        _identifier = identifier;
+        _expression = expression;
     }
 
     public TypeNode GetTypeChild() {
-        return (TypeNode) children[0];
+        return _type;
     }
 
     public IdentifierNode GetIdentifierChild() {
-        return (IdentifierNode) children[1];
+        return _identifier;
     }
 
     public ExpressionNode GetExpressionChild() {
-        return (ExpressionNode) children[2];
+        return _expression;
+    }
+
+    @Override
+    public <T> T Accept(IVisitor<T> visitor) {
+        return visitor.Visit(this);
     }
 }

--- a/src/main/java/org/flowsoft/flowg/nodes/ExpressionNode.java
+++ b/src/main/java/org/flowsoft/flowg/nodes/ExpressionNode.java
@@ -1,19 +1,4 @@
 package org.flowsoft.flowg.nodes;
 
-public class ExpressionNode extends Node {
-    public ExpressionNode(NumberLiteralNode child) {
-        super(new Node[] {child});
-    }
-
-    public ExpressionNode(BooleanLiteralNode child) {
-        super(new Node[] {child});
-    }
-
-    public NumberLiteralNode GetNumberLiteralChild() {
-        return (NumberLiteralNode) children[0];
-    }
-
-    public BooleanLiteralNode GetBooleanLiteralChild() {
-        return (BooleanLiteralNode) children[0];
-    }
+public interface ExpressionNode extends INode {
 }

--- a/src/main/java/org/flowsoft/flowg/nodes/INode.java
+++ b/src/main/java/org/flowsoft/flowg/nodes/INode.java
@@ -1,0 +1,7 @@
+package org.flowsoft.flowg.nodes;
+
+import org.flowsoft.flowg.IVisitor;
+
+public interface INode {
+    <T> T Accept(IVisitor<T> visitor);
+}

--- a/src/main/java/org/flowsoft/flowg/nodes/IdentifierNode.java
+++ b/src/main/java/org/flowsoft/flowg/nodes/IdentifierNode.java
@@ -1,11 +1,20 @@
 package org.flowsoft.flowg.nodes;
 
+import org.flowsoft.flowg.IVisitor;
+
 public class IdentifierNode extends Node {
-    public IdentifierNode(String identifier) {
-        super(identifier);
+    private final String _value;
+
+    public IdentifierNode(String value) {
+        _value = value;
     }
 
     public String GetValue() {
-        return (String) value;
+        return _value;
+    }
+
+    @Override
+    public <T> T Accept(IVisitor<T> visitor) {
+        return visitor.Visit(this);
     }
 }

--- a/src/main/java/org/flowsoft/flowg/nodes/Node.java
+++ b/src/main/java/org/flowsoft/flowg/nodes/Node.java
@@ -1,39 +1,9 @@
 package org.flowsoft.flowg.nodes;
 
-import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
-
-public abstract class Node {
-    protected Node[] children;
-    protected Object value;
-
-    protected Node(Object value) {
-        this(value, new Node[0]);
-    }
-
-    protected Node(Node[] children) {
-        this(null, children);
-    }
-
-    protected Node(Object value, Node[] children){
-        this.value = value;
-        this.children = children;
-    }
-
-    public void Print() {
-        Print(0);
-    }
-
-    private void Print(int indentation) {
-        System.out.println("  ".repeat(indentation) + this);
-        for (var child : children) {
-            child.Print(indentation + 1);
-        }
-    }
-
+public abstract class Node implements INode {
     @Override
     public String toString() {
-        return getClass().getSimpleName() + (value != null ? "{value=" + value + '}' : "");
+        return getClass().getSimpleName();
     }
 }
 

--- a/src/main/java/org/flowsoft/flowg/nodes/NumberLiteralNode.java
+++ b/src/main/java/org/flowsoft/flowg/nodes/NumberLiteralNode.java
@@ -1,13 +1,22 @@
 package org.flowsoft.flowg.nodes;
 
+import org.flowsoft.flowg.IVisitor;
+
 import java.math.BigDecimal;
 
-public class NumberLiteralNode extends Node {
+public class NumberLiteralNode extends Node implements ExpressionNode {
+    private final BigDecimal _value;
+
     public NumberLiteralNode(BigDecimal value) {
-        super(value);
+        _value = value;
     }
 
     public BigDecimal GetValue() {
-        return (BigDecimal) value;
+        return _value;
+    }
+
+    @Override
+    public <T> T Accept(IVisitor<T> visitor) {
+        return visitor.Visit(this);
     }
 }

--- a/src/main/java/org/flowsoft/flowg/nodes/ProgramNode.java
+++ b/src/main/java/org/flowsoft/flowg/nodes/ProgramNode.java
@@ -1,11 +1,19 @@
 package org.flowsoft.flowg.nodes;
 
+import org.flowsoft.flowg.IVisitor;
+
 public class ProgramNode extends Node {
+    private final StatementListNode _child;
     public ProgramNode(StatementListNode child) {
-        super(new Node[] {child});
+        _child = child;
     }
 
     public StatementListNode GetChild() {
-        return (StatementListNode) children[0];
+        return _child;
+    }
+
+    @Override
+    public <T> T Accept(IVisitor<T> visitor) {
+        return visitor.Visit(this);
     }
 }

--- a/src/main/java/org/flowsoft/flowg/nodes/StatementListNode.java
+++ b/src/main/java/org/flowsoft/flowg/nodes/StatementListNode.java
@@ -1,23 +1,30 @@
 package org.flowsoft.flowg.nodes;
 
+import org.flowsoft.flowg.IVisitor;
+
 public class StatementListNode extends Node {
-    public StatementListNode(StatementNode leftChild, StatementListNode rightChild) {
-        super(new Node[] {leftChild, rightChild});
-    }
+    private final StatementNode _statement;
+    private final StatementListNode _statementList;
 
     public StatementListNode(StatementNode child) {
-        super(new Node[]{child});
+        this(child, null);
     }
 
-    public StatementNode GetLeftChild() {
-        return (StatementNode) children[0];
+    public StatementListNode(StatementNode leftChild, StatementListNode rightChild) {
+        _statement = leftChild;
+        _statementList = rightChild;
     }
 
-    public StatementListNode GetRightChild() {
-        if (children.length == 2)
-            return (StatementListNode) children[1];
-        else
-            return null;
+    public StatementNode GetStatementChild() {
+        return _statement;
     }
 
+    public StatementListNode GetStatementListChild() {
+        return _statementList;
+    }
+
+    @Override
+    public <T> T Accept(IVisitor<T> visitor) {
+        return visitor.Visit(this);
+    }
 }

--- a/src/main/java/org/flowsoft/flowg/nodes/StatementNode.java
+++ b/src/main/java/org/flowsoft/flowg/nodes/StatementNode.java
@@ -1,11 +1,19 @@
 package org.flowsoft.flowg.nodes;
 
+import org.flowsoft.flowg.IVisitor;
+
 public class StatementNode extends Node {
+    private final DeclarationNode _declaration;
     public StatementNode(DeclarationNode child) {
-        super(new Node[] {child});
+        _declaration = child;
     }
 
     public DeclarationNode GetChild() {
-        return (DeclarationNode) children[0];
+        return _declaration;
+    }
+
+    @Override
+    public <T> T Accept(IVisitor<T> visitor) {
+        return visitor.Visit(this);
     }
 }

--- a/src/main/java/org/flowsoft/flowg/nodes/TypeNode.java
+++ b/src/main/java/org/flowsoft/flowg/nodes/TypeNode.java
@@ -1,11 +1,19 @@
 package org.flowsoft.flowg.nodes;
 
+import org.flowsoft.flowg.IVisitor;
+
 public class TypeNode extends Node {
+    private final String _type;
     public TypeNode(String type) {
-        super(type);
+        _type = type;
     }
 
     public String GetValue() {
-        return (String) value;
+        return _type;
+    }
+
+    @Override
+    public <T> T Accept(IVisitor<T> visitor) {
+        return visitor.Visit(this);
     }
 }

--- a/src/test/java/org/flowsoft/flowg/tests/ParserTests.java
+++ b/src/test/java/org/flowsoft/flowg/tests/ParserTests.java
@@ -3,7 +3,7 @@ package org.flowsoft.flowg.tests;
 import static com.google.common.truth.Truth.assertThat;
 
 import org.flowsoft.flowg.Yylex;
-import org.flowsoft.flowg.nodes.ProgramNode;
+import org.flowsoft.flowg.nodes.*;
 import org.flowsoft.flowg.parser;
 import org.junit.Test;
 
@@ -16,17 +16,16 @@ public class ParserTests {
     public void ParseNumberVariableDeclaration() throws Exception {
         var programNode = Parse("number hello = 2;");
         var statementList = programNode.GetChild();
-        assertThat(statementList.GetRightChild()).isNull();
+        assertThat(statementList.GetStatementListChild()).isNull();
 
-        var statement = statementList.GetLeftChild();
+        var statement = statementList.GetStatementChild();
         var declaration = statement.GetChild();
         var type = declaration.GetTypeChild();
         var identifier = declaration.GetIdentifierChild();
         assertThat(type.GetValue()).isEqualTo("number");
         assertThat(identifier.GetValue()).isEqualTo("hello");
 
-        var expression = declaration.GetExpressionChild();
-        var numberLiteral = expression.GetNumberLiteralChild();
+        var numberLiteral = (NumberLiteralNode)declaration.GetExpressionChild();
         assertThat(numberLiteral.GetValue()).isEqualTo(new BigDecimal("2"));
     }
 
@@ -34,18 +33,17 @@ public class ParserTests {
     public void ParseBooleanVariableDeclaration() throws Exception {
         var programNode = Parse("bool world = true;");
         var statementList = programNode.GetChild();
-        assertThat(statementList.GetRightChild()).isNull();
+        assertThat(statementList.GetStatementListChild()).isNull();
 
-        var statement = statementList.GetLeftChild();
+        var statement = statementList.GetStatementChild();
         var declaration = statement.GetChild();
         var type = declaration.GetTypeChild();
         var identifier = declaration.GetIdentifierChild();
         assertThat(type.GetValue()).isEqualTo("bool");
         assertThat(identifier.GetValue()).isEqualTo("world");
 
-        var expression = declaration.GetExpressionChild();
-        var booleanLiteralNode = expression.GetBooleanLiteralChild();
-        assertThat(booleanLiteralNode.GetValue()).isEqualTo(true);
+        var booleanLiteral = (BooleanLiteralNode)declaration.GetExpressionChild();
+        assertThat(booleanLiteral.GetValue()).isEqualTo(true);
     }
 
     private ProgramNode Parse(String input) throws Exception {


### PR DESCRIPTION
Instead of adding methods to the nodes we can make use of a visitor.
This makes the nodes accept a visitor.
The visitor is generic such that it can return whatever it needs.
There are currently implemented two visitors:
PrettyPrintingVisitor and TreePrintingVisitor.
The pretty printing visitor prints the AST as source code.
The tree printing visitor prints the AST itself.