### PR TITLE
Redo LexerTests with theories

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,16 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
-  <component name="MavenCompilerTasksManager">
-    <option name="beforeCompileTasks">
-      <set>
-        <MavenCompilerTask>
-          <option name="goal" value="package" />
-          <option name="projectPath" value="$PROJECT_DIR$/pom.xml" />
-        </MavenCompilerTask>
-      </set>
-    </option>
-  </component>
   <component name="MavenProjectsManager">
     <option name="originalFiles">
       <list>

--- a/src/main/cup/flowg.cup
+++ b/src/main/cup/flowg.cup
@@ -4,6 +4,8 @@ import java.util.ArrayList;
 import java_cup.runtime.*;
 import org.flowsoft.flowg.nodes.*;
 
+terminal INVALID;
+
 terminal TypeNode TYPE;
 
 terminal IdentifierNode IDENTIFIER;

--- a/src/main/jflex/flowg.flex
+++ b/src/main/jflex/flowg.flex
@@ -27,11 +27,12 @@ import java.math.BigDecimal;
 
 
 Type = "number"|"bool"|"point"|"void"
-Identifier = [:jletter:][:jletterdigit:]*
+Identifier = [a-zA-Z][a-zA-Z0-9]*
 Number = [0-9]+(\.[0-9]+)?
 Whitespace = [\ \n]
 NewLine = \n
 Comment = \/\/[^\n]*
+Anything = .
 
 %%
 
@@ -61,5 +62,7 @@ Comment = \/\/[^\n]*
 "*" { return symbol(sym.TIMES); }
 "/" { return symbol(sym.DIVIDE); }
 
-
+// This catches any error.
+// Never match this symbol unless it is to report is as an error!
+{Anything} { return symbol(sym.INVALID); }
 


### PR DESCRIPTION
The lexer now always matches the input no matter what.
If a lexer error has occurred the INVALID symbol has been placed in the token stream.
This has been used in the test to detect invalid inputs.