### PR TITLE
Add function scopes

### DIFF
--- a/src/main/java/org/flowsoft/flowg/visitors/Cloneable.java
+++ b/src/main/java/org/flowsoft/flowg/visitors/Cloneable.java
@@ -1,0 +1,5 @@
+package org.flowsoft.flowg.visitors;
+
+public interface Cloneable<T> {
+    public T Clone();
+}

--- a/src/main/java/org/flowsoft/flowg/visitors/FunctionEntry.java
+++ b/src/main/java/org/flowsoft/flowg/visitors/FunctionEntry.java
@@ -6,17 +6,19 @@ import org.flowsoft.flowg.nodes.StatementListNode;
 
 import java.util.ArrayList;
 
-public class FunctionEntry {
+public class FunctionEntry implements Cloneable<FunctionEntry> {
     private final Type _returnType;
     private final String _identifier;
     private final ArrayList<FormalParameterNode> _formalParameters;
     private final StatementListNode _functionBody;
+    private final SymbolTable _symbolTable;
 
-    public FunctionEntry(Type returnType, String identifier, ArrayList<FormalParameterNode> formalParameters, StatementListNode functionBody) {
+    public FunctionEntry(Type returnType, String identifier, ArrayList<FormalParameterNode> formalParameters, StatementListNode functionBody, SymbolTable symbolTable) {
         _returnType = returnType;
         _identifier = identifier;
         _formalParameters = formalParameters;
         _functionBody = functionBody;
+        _symbolTable = symbolTable;
     }
 
     public Type GetReturnType() {
@@ -33,5 +35,12 @@ public class FunctionEntry {
 
     public StatementListNode GetFunctionBody() {
         return _functionBody;
+    }
+
+    public SymbolTable GetSymbolTable() { return _symbolTable; }
+
+    @Override
+    public FunctionEntry Clone() {
+        return new FunctionEntry(GetReturnType(), GetIdentifier(), GetFormalParameters(), GetFunctionBody(), GetSymbolTable());
     }
 }

--- a/src/main/java/org/flowsoft/flowg/visitors/RuntimeSymbolTable.java
+++ b/src/main/java/org/flowsoft/flowg/visitors/RuntimeSymbolTable.java
@@ -1,0 +1,58 @@
+package org.flowsoft.flowg.visitors;
+
+import org.flowsoft.flowg.TypeException;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class RuntimeSymbolTable {
+    private final SymbolTable _base;
+    private final RuntimeSymbolTable _parent;
+    
+    private final Map<String, ExpressionValue> _variableMap = new HashMap<>();
+
+    public RuntimeSymbolTable(SymbolTable base, RuntimeSymbolTable parent) {
+        _base = base;
+        _parent = parent;
+
+        for (var variable : base.GetVariables()) {
+            _variableMap.put(variable.GetIdentifier(), null);
+        }
+    }
+
+    public RuntimeSymbolTable Create(SymbolTable symbolTable) {
+        return new RuntimeSymbolTable(symbolTable, this);
+    }
+
+    public void SetValue(String identifier, ExpressionValue expressionValue) throws TypeException {
+        if (_variableMap.containsKey(identifier)) {
+            _variableMap.put(identifier, expressionValue);
+        }
+        else
+        {
+            throw new TypeException();
+        }
+    }
+
+    public ExpressionValue LookupVariable(String identifier) throws TypeException {
+        if (_variableMap.containsKey(identifier)) {
+            var value = _variableMap.get(identifier);
+            assert(value != null);
+            return value;
+        }
+
+        if (_parent != null) {
+            return _parent.LookupVariable(identifier);
+        }
+
+        throw new TypeException();
+    }
+
+    public FunctionEntry LookupFunction(String identifier) throws TypeException {
+        return _base.LookupFunction(identifier);
+    }
+
+    public RuntimeSymbolTable GetParent() {
+        return _parent;
+    }
+}

--- a/src/main/java/org/flowsoft/flowg/visitors/VariableEntry.java
+++ b/src/main/java/org/flowsoft/flowg/visitors/VariableEntry.java
@@ -2,21 +2,26 @@ package org.flowsoft.flowg.visitors;
 
 import org.flowsoft.flowg.Type;
 
-public class VariableEntry {
-
-    public VariableEntry(String identifier, Type type, ExpressionValue expressionValue) {
-        Identifier = identifier;
-        Type = type;
-        Value = expressionValue;
-    }
+public class VariableEntry implements Cloneable<VariableEntry> {
+    private final String _identifier;
+    private final Type _type;
 
     public VariableEntry(String identifier, Type type) {
-        Identifier = identifier;
-        Type = type;
-        Value = null;
+        _identifier = identifier;
+        _type = type;
     }
 
-    public String Identifier;
-    public Type Type;
-    public ExpressionValue Value;
+    public String GetIdentifier() {
+        return _identifier;
+    }
+
+    public Type GetType() {
+        return _type;
+    }
+
+
+    @Override
+    public VariableEntry Clone() {
+        return new VariableEntry(GetIdentifier(), GetType());
+    }
 }

--- a/src/test/java/org/flowsoft/flowg/tests/CodeGeneratingTests.java
+++ b/src/test/java/org/flowsoft/flowg/tests/CodeGeneratingTests.java
@@ -206,7 +206,7 @@ public class CodeGeneratingTests {
         var node = thing.GetNode();
         var expected = thing.GetExpected();
 
-        var value = node.Accept(new CodeGeneratingVisitor(new SymbolTable()));
+        var value = node.Accept(new CodeGeneratingVisitor(new SymbolTable(null)));
         var actual = value.GetNumber();
 
         assertThat(value.GetType()).isEqualTo(Type.Number);
@@ -218,7 +218,7 @@ public class CodeGeneratingTests {
         var node = thing.GetNode();
         var expected = thing.GetExpected();
 
-        var value = node.Accept(new CodeGeneratingVisitor(new SymbolTable()));
+        var value = node.Accept(new CodeGeneratingVisitor(new SymbolTable(null)));
         var actual = value.GetPoint();
 
         assertThat(value.GetType()).isEqualTo(Type.Point);
@@ -241,9 +241,9 @@ public class CodeGeneratingTests {
         node.Accept(codeGen);
 
 
-        var symbolTable = typeChecker.GetSymbolTable();
+        var symbolTable = codeGen.GetSymbolTable();
 
-        assertTrue(symbolTable.LookupVariable("x").Value.GetNumber().compareTo(new BigDecimal("4")) == 0);
+        assertTrue(symbolTable.LookupVariable("x").GetNumber().compareTo(new BigDecimal("4")) == 0);
     }
 
     @Test


### PR DESCRIPTION
Functions now have a scope.

The SymbolTable class no longer holds value information.
This responsibility is delegated to the RuntimeSymbolTable class.
It maps an identifier to a value.