### PR TITLE
Report invalid tokens

### DIFF
--- a/src/main/cup/flowg.cup
+++ b/src/main/cup/flowg.cup
@@ -9,8 +9,6 @@ import org.flowsoft.flowg.nodes.functions.*;
 import org.flowsoft.flowg.nodes.math.functions.*;
 import org.flowsoft.flowg.nodes.math.operators.*;
 
-terminal INVALID;
-
 terminal TypeNode TYPE;
 
 terminal IdentifierNode IDENTIFIER;

--- a/src/main/java/org/flowsoft/flowg/InvalidTokenException.java
+++ b/src/main/java/org/flowsoft/flowg/InvalidTokenException.java
@@ -1,0 +1,21 @@
+package org.flowsoft.flowg;
+
+import java_cup.runtime.ComplexSymbolFactory.Location;
+
+public class InvalidTokenException extends Exception {
+    private final Location _left;
+    private final Location _right;
+
+    public InvalidTokenException(Location left, Location right) {
+        _left = left;
+        _right = right;
+    }
+
+    public Location GetLeft() {
+        return _left;
+    }
+
+    public Location GetRight() {
+        return _right;
+    }
+}

--- a/src/main/java/org/flowsoft/flowg/main.java
+++ b/src/main/java/org/flowsoft/flowg/main.java
@@ -103,6 +103,10 @@ public class main {
             writer.write(str);
             writer.close();
         }
+        catch (InvalidTokenException e) {
+            System.err.format("%s:%d:%d: error: invalid token\n", e.GetLeft().getUnit(), e.GetLeft().getLine(), e.GetLeft().getColumn());
+            System.err.println(GetLine(file, e.GetLeft(), e.GetRight()));
+        }
         catch (ExpectedTypeException e) {
             System.err.format("%s:%d:%d: error: expected %s but got %s\n", e.GetLeft().getUnit(), e.GetLeft().getLine(), e.GetLeft().getColumn(), TypeHelper.TypeToString(e.GetExpected()), TypeHelper.TypeToString(e.GetActual()));
             System.err.println(GetLine(file, e.GetLeft(), e.GetRight()));

--- a/src/main/jflex/flowg.flex
+++ b/src/main/jflex/flowg.flex
@@ -20,6 +20,7 @@ import java.math.BigDecimal;
 %implements java_cup.runtime.Scanner
 %function next_token
 %type java_cup.runtime.Symbol
+%yylexthrow InvalidTokenException
 %eofval{
   return symbol("EOF", sym.EOF);
 %eofval}
@@ -139,6 +140,5 @@ Anything = .
 "!" { return symbol("!", sym.NOT); }
 
 // This catches any error.
-// Never match this symbol unless it is to report is as an error!
-{Anything} { return symbol("invalid", sym.INVALID); }
+{Anything} { throw new InvalidTokenException(leftLocation(), rightLocation()); }
 

--- a/src/test/java/org/flowsoft/flowg/tests/LexerTests.java
+++ b/src/test/java/org/flowsoft/flowg/tests/LexerTests.java
@@ -1,7 +1,9 @@
 package org.flowsoft.flowg.tests;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
 
+import org.flowsoft.flowg.InvalidTokenException;
 import org.flowsoft.flowg.Yylex;
 import org.flowsoft.flowg.sym;
 import org.junit.experimental.theories.DataPoints;
@@ -52,7 +54,7 @@ public class LexerTests {
     };
 
     @Theory
-    public void TestLexerSuccess(TextSymbolPair pair) throws IOException {
+    public void TestLexerSuccess(TextSymbolPair pair) throws IOException, InvalidTokenException {
         var lexer = new Yylex(new StringReader(pair.GetText()), "test");
         for (int symbol : pair.GetSymbols()) {
             assertThat(lexer.next_token().sym).isEqualTo(symbol);
@@ -61,9 +63,9 @@ public class LexerTests {
     }
 
     @Theory
-    public void TestLexerFailure(String input) throws IOException {
+    public void TestLexerFailure(String input) throws IOException, InvalidTokenException {
         var lexer = new Yylex(new StringReader(input), "test");
-        assertThat(lexer.next_token().sym).isEqualTo(sym.INVALID);
+        assertThrows(InvalidTokenException.class, lexer::next_token);
         assertThat(lexer.next_token().sym).isEqualTo(sym.EOF);
     }
 


### PR DESCRIPTION
Instead of emitting an invalid token we now throw an `InvalidTokenException` this is caught in main like the type error exceptions.
Depends on #41 
